### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[*.{json,yml,yaml}]
+indent_size = 2
+indent_style = space
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.py]


### PR DESCRIPTION
This file will ensure that GitHub makes all YAML files use 2-space indentation, and that Python files will use a 4-space indentation. In order to make sure that your editor adheres to this, install the EditorConfig plugin.